### PR TITLE
[Fix] 폰트 이름 실수 수정

### DIFF
--- a/theLastPush/theLastPush/Screens/JuseojoVC/JuseojoView.swift
+++ b/theLastPush/theLastPush/Screens/JuseojoVC/JuseojoView.swift
@@ -100,7 +100,7 @@ class JuseojoView: UIView {
 	let explainLabel: UILabel = {
 		let label = UILabel()
 		var attributes = NSMutableAttributedString()
-		let mediumFont: [NSAttributedString.Key: Any] = [.font: UIFont(name: "IBMPlexSansKR-Mediu", size: 14).unwrap(fontSize: 14)]
+		let mediumFont: [NSAttributedString.Key: Any] = [.font: UIFont(name: "IBMPlexSansKR-Medium", size: 14).unwrap(fontSize: 14)]
 		let regularFont: [NSAttributedString.Key: Any] = [.font: UIFont(name: "IBMPlexSansKR-Regular", size: 14).unwrap(fontSize: 14)]
 		let blueFont: [NSAttributedString.Key : Any] = [
 			.font: UIFont(name: "IBMPlexSansKR-Regular", size: 14).unwrap(fontSize: 14),


### PR DESCRIPTION
- IBMPlexSansKR-Mediu -> IBMPlexSansKR-Medium

## 🔥 작업한 내용
- UIFont+ unwrap 테스트하느라 수정한 폰트 이름을 그대로 두고 푸쉬하여 수정하였습니다. 


## ⭐️ PR Point
- 폰트 이름 수정


## 📸 스크린샷


## 🚨 관련 이슈
- Resolved: #15
-  폰트 이름 실수 수정

