### PR TITLE
Chore: 프로필 이미지 레이아웃 정리 및 위치 조정

### DIFF
--- a/theLastPush/theLastPush/Screens/MoriVC/MoriVC.swift
+++ b/theLastPush/theLastPush/Screens/MoriVC/MoriVC.swift
@@ -90,7 +90,7 @@ final class MoriVC: UIViewController {
         contentView.addSubview(cardView) // 하얀색 박스 영역
         
         cardView.snp.makeConstraints { make in // cardView의 제약 조건
-            make.top.equalTo(contentView).offset(50)
+            make.top.equalTo(contentView).offset(100)
             make.leading.trailing.equalTo(contentView).inset(20)
             make.bottom.equalTo(contentView).inset(20)
         }
@@ -100,8 +100,8 @@ final class MoriVC: UIViewController {
     private func setupProfileImageLayout() {
         cardView.addSubview(profileImageView)
         profileImageView.snp.makeConstraints { make in
-            make.top.equalTo(cardView).offset(24)
             make.centerX.equalTo(cardView)
+            make.centerY.equalTo(cardView.snp.top) // 수직(Y축) 중앙선을 cardView의 top에 맞춤
             make.width.height.equalTo(100)
         }
     }
@@ -258,7 +258,6 @@ final class MoriVC: UIViewController {
     private func setupCardViewStyle() {
         cardView.backgroundColor = .white
         cardView.layer.cornerRadius = 16
-        cardView.layer.masksToBounds = true // 자식 뷰가 둥근 테두리 밖으로 빠져나가면 잘라서 보이지 않도록 함
     }
     
     // MARK: - 프로필 이미지 디자인


### PR DESCRIPTION
## 🔥 작업한 내용
- 프로필 이미지 레이아웃 정리 및 위치 조정했습니다.


## ⭐️ PR Point
- 저 원하던 디자인으로 수정했어요!!

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/6e67c2c6-5c97-4c47-b746-04e47cdf1132" alt="시뮬레이터 스크린샷" width="300" />


## 🚨 관련 이슈
- Resolved: #28 


